### PR TITLE
Scrabble scoring update to regex in spec

### DIFF
--- a/spec/scrabble-scorer.spec.js
+++ b/spec/scrabble-scorer.spec.js
@@ -17,7 +17,7 @@ describe("Scrabble Scorer solution", function() {
 		let transformedObj = solution.transform(solution.oldPointStructure);
 		let letterKeys = Object.keys(transformedObj);
 		
-		let lettersEx = /[a-z]/g;
+		let lettersEx = /[a-z ]/g;
 
 		// .every() returns true if each item in the array passes the match
 		let expected = letterKeys.every(function(l) {


### PR DESCRIPTION
The Scrabble Scorer's bonus missions includes the task to allow words spelled with a space, and to assign the space a point value of zero. [Instructions here](https://education.launchcode.org/intro-to-professional-web-dev/assignments/scrabble-scorer.html#bonus-missions).

Regex in the spec file only allows for letters A-Z, not a space. This change means the test will pass if the students elect to perform the bonus mission.